### PR TITLE
feat: add option to use specific checkov version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,20 @@
 # env0 Checkov Plugin
 
-  
-
 This env0 Checkov Plugin will allow you to run `checkov` scans on an IaC directory as a part of your custom flow. To use this plugin, you will need to use version 2 of `env0.yml`.
 
-  
-
-We are using Checkov version `2.2.105`
-
-  
+You can specify a particular version of Checkov to use by adding `checkov_version` to the inputs of the action in your env0.yml. If `checkov_version` is not specified or is set to "latest", the plugin will use the latest version of Checkov.
 
 ## Inputs
 
-  
-
 The Checkov plugin accepts the following inputs:
 
-* directory (required) - the path to the directory with the IaC code to scan (the root folder is your project's root folder)
-
-* flags - a string containing additional flags as one string
-
+* `directory` (required) - The path to the directory with the IaC code to scan (the root folder is your project's root folder).
+* `flags` - A string containing additional flags as one string.
+* `checkov_version` (optional) - The version of Checkov to install. If not specified or "latest", the latest version is installed.
 
 ## Example Usage
 
-  
-
-In this example we will run `checkov` scan on our tf folder before the "Terraform Plan" step of a deploy. We will call that step "My Step Name":
+In this example we will run a `checkov` scan on our tf folder before the "Terraform Plan" step of a deploy, using Checkov version 2.2.105. We will call that step "My Step Name":
 
 ```yaml
 version: 2
@@ -38,10 +27,9 @@ deploy:
           inputs:
             directory: .
             flags: --framework terraform 
+            checkov_version: 2.2.105
 
 ```
-
-  
 
 ## Further Reading
 

--- a/env0.plugin.yml
+++ b/env0.plugin.yml
@@ -6,7 +6,15 @@ inputs:
     required: true
   flags:
     description: Additional Checkov flags
+  checkov_version:
+    description: The version of Checkov to install.
+    required: false
+    default: "latest"
 run:
   exec: |
-    sudo pip install -U checkov
+    if [[ "${inputs.checkov_version}" == "latest" ]]; then
+      sudo pip install -U checkov
+    else
+      sudo pip install checkov==${inputs.checkov_version}
+    fi
     checkov --directory ${inputs.directory} ${inputs.flags}


### PR DESCRIPTION
In this revised version, the optional `checkov_version` parameter allows users to specify a particular version of Checkov to install. 

If a user doesn't specify a version (or specifies "latest"), the action installs the latest version of Checkov. 

Please note, that the version should be specified in the valid format like "2.0.0".

Close #1 