### PR TITLE
Revert "feat: add option to use specific checkov version (#2)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,31 @@
 # env0 Checkov Plugin
 
+  
+
 This env0 Checkov Plugin will allow you to run `checkov` scans on an IaC directory as a part of your custom flow. To use this plugin, you will need to use version 2 of `env0.yml`.
 
-You can specify a particular version of Checkov to use by adding `checkov_version` to the inputs of the action in your env0.yml. If `checkov_version` is not specified or is set to "latest", the plugin will use the latest version of Checkov.
+  
+
+We are using Checkov version `2.2.105`
+
+  
 
 ## Inputs
 
+  
+
 The Checkov plugin accepts the following inputs:
 
-* `directory` (required) - The path to the directory with the IaC code to scan (the root folder is your project's root folder).
-* `flags` - A string containing additional flags as one string.
-* `checkov_version` (optional) - The version of Checkov to install. If not specified or "latest", the latest version is installed.
+* directory (required) - the path to the directory with the IaC code to scan (the root folder is your project's root folder)
+
+* flags - a string containing additional flags as one string
+
 
 ## Example Usage
 
-In this example we will run a `checkov` scan on our tf folder before the "Terraform Plan" step of a deploy, using Checkov version 2.2.105. We will call that step "My Step Name":
+  
+
+In this example we will run `checkov` scan on our tf folder before the "Terraform Plan" step of a deploy. We will call that step "My Step Name":
 
 ```yaml
 version: 2
@@ -27,9 +38,10 @@ deploy:
           inputs:
             directory: .
             flags: --framework terraform 
-            checkov_version: 2.2.105
 
 ```
+
+  
 
 ## Further Reading
 

--- a/env0.plugin.yml
+++ b/env0.plugin.yml
@@ -6,15 +6,7 @@ inputs:
     required: true
   flags:
     description: Additional Checkov flags
-  checkov_version:
-    description: The version of Checkov to install.
-    required: false
-    default: "latest"
 run:
   exec: |
-    if [[ "${inputs.checkov_version}" == "latest" ]]; then
-      sudo pip install -U checkov
-    else
-      sudo pip install checkov==${inputs.checkov_version}
-    fi
+    sudo pip install -U checkov
     checkov --directory ${inputs.directory} ${inputs.flags}


### PR DESCRIPTION
This reverts commit 9197b559d79d237692885d1c7b41eebaa502ce82.

Seems like #2  broke this plugin

```
Plugin file is not valid: /inputs/checkov_version - must NOT have additional properties
```

while this is the env0 yaml
```
version: 2
deploy:
  steps:
    terraformPlan:
      before:
      - name: Checkov
        use: https://github.com/env0/env0-checkov-plugin
        inputs:
          directory: .
          flags: --framework terraform
```

rolling back to fix the plugin